### PR TITLE
documentSymbol / outline support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
         "node": true,
         "es6": true
     },
+    "root": true,
     "extends": [
         "standard-with-typescript",
         "plugin:@typescript-eslint/recommended"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ MATLAB language server supports these editors by installing the corresponding ex
 * Visual Studio&reg; Code — [MATLAB extension for Visual Studio Code](https://github.com/mathworks/MATLAB-extension-for-vscode)
 
 ## Release Notes
+### 1.1.0
+Release date: 2023-05-12
+
+* Add support for documentSymbol (outline).
+
 ### 1.0.0
 Release date: 2023-04-26
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@ MATLAB&reg; language server implements the Microsoft&reg; [Language Server Proto
 
 ## Features Implemented
 MATLAB language server implements several Language Server Protocol features and their related services:
-* Code diagnostics — [publishDiagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics) 
-* Quick fixes — [codeActionProvider](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeAction) 
-* Document formatting — [documentFormattingProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting) 
+* Code diagnostics — [publishDiagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics)
+* Quick fixes — [codeActionProvider](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeAction)
+* Document formatting — [documentFormattingProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting)
 * Code completions — [completionProvider](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion)
 * Function signature help — [signatureHelpProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp)
-* Go to definition — [definitionProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_definition) 
+* Go to definition — [definitionProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_definition)
 * Go to references — [referencesProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references)
+* Document symbols — [documentSymbol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol)
 
 ## Clients
 MATLAB language server supports these editors by installing the corresponding extension:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matlab-language-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Language Server for MATLAB code",
   "main": "./src/index.ts",
   "scripts": {

--- a/src/indexing/FileInfoIndex.ts
+++ b/src/indexing/FileInfoIndex.ts
@@ -109,9 +109,8 @@ class FileInfoIndex {
 
         if (rawCodeData.classInfo.hasClassInfo) {
             let classInfo = this.classInfoCache.get(rawCodeData.classInfo.name)
-            if (classInfo == null || rawCodeData.classInfo.isClassDef) {
-                // Class not discovered yet or we're parsing the main classdef file
-                // need to create info object
+            if (classInfo == null) {
+                // Class not discovered yet - need to create info object
                 classInfo = new MatlabClassInfo(rawCodeData.classInfo, uri)
                 this.classInfoCache.set(classInfo.name, classInfo)
             } else {
@@ -180,6 +179,12 @@ export class MatlabClassInfo {
             this.baseClasses = rawClassInfo.baseClasses
             this.range = convertRange(rawClassInfo.range)
             this.declaration = convertRange(rawClassInfo.declaration)
+
+            // Since this is the classdef, we'll update all members. Clear them out here.
+            this.enumerations.clear()
+            this.properties.clear()
+            this.methods.clear()
+            this.parsePropertiesAndEnums(rawClassInfo)
         } else {
             // Data contains supplementary class info - nothing to do in this situation
         }

--- a/src/indexing/FileInfoIndex.ts
+++ b/src/indexing/FileInfoIndex.ts
@@ -109,8 +109,9 @@ class FileInfoIndex {
 
         if (rawCodeData.classInfo.hasClassInfo) {
             let classInfo = this.classInfoCache.get(rawCodeData.classInfo.name)
-            if (classInfo == null) {
-                // Class not discovered yet - need to create info object
+            if (classInfo == null || rawCodeData.classInfo.isClassDef) {
+                // Class not discovered yet or we're parsing the main classdef file
+                // need to create info object
                 classInfo = new MatlabClassInfo(rawCodeData.classInfo, uri)
                 this.classInfoCache.set(classInfo.name, classInfo)
             } else {
@@ -364,6 +365,15 @@ export class MatlabCodeData {
      */
     get isClassDef (): boolean {
         return this.classInfo != null
+    }
+
+    /**
+     * Whether or not the code data represents a main classdef file.
+     * For @aclass/aclass.m this returns true
+     * For @aclass/amethod.m this returns false.
+     */
+    get isMainClassDefDocument (): boolean {
+        return this.isClassDef && this.uri === this.classInfo?.uri
     }
 
     /**

--- a/src/lifecycle/MatlabLifecycleManager.ts
+++ b/src/lifecycle/MatlabLifecycleManager.ts
@@ -91,6 +91,41 @@ class MatlabLifecycleManager {
     }
 
     /**
+     * Gets the active connection to MATLAB or waits for one to be established.
+     * Does not attempt to create a connection if one does not currently exist.
+     * Immediately returns null if the user set the MATLAB connection timing to
+     * never.
+     *
+     * @returns The connection to MATLAB, or null if connection timing is never
+     */
+    async getMatlabConnectionAsync (): Promise<MatlabConnection | null> {
+        if (await this._isMatlabConnectionTimingNever()) {
+            return null
+        }
+        const isMatlabReady = this._matlabProcess?.isMatlabReady() ?? false
+        if (isMatlabReady) {
+            const conn = this._matlabProcess?.getConnection()
+            if (conn !== null && conn !== undefined) {
+                return conn
+            }
+        }
+        const result = new Promise<MatlabConnection>((resolve, reject) => {
+            this.addMatlabLifecycleListener((error, evt) => {
+                if (error !== null) {
+                    reject(error)
+                }
+                if (evt.matlabStatus === 'connected') {
+                    const conn = this.getMatlabConnection()
+                    if (conn !== null) {
+                        resolve(conn)
+                    }
+                }
+            })
+        })
+        return await result
+    }
+
+    /**
      * Gets the active connection to MATLAB. If one does not currently exist, this will
      * attempt to establish a connection.
      *
@@ -105,8 +140,7 @@ class MatlabLifecycleManager {
         }
 
         // No active connection - should create a connection if desired
-        const connectionTiming = (await ConfigurationManager.getConfiguration()).matlabConnectionTiming
-        if (connectionTiming !== ConnectionTiming.Never) {
+        if (await this._isMatlabConnectionTimingNever()) {
             const matlabProcess = await this.connectToMatlab(connection)
             return matlabProcess.getConnection()
         }
@@ -197,6 +231,15 @@ class MatlabLifecycleManager {
                 matlabStatus: status
             })
         })
+    }
+
+    /**
+     *
+     * @returns True if the MATLAB connection timing setting is set to never. Returns false otherwise.
+     */
+    private async _isMatlabConnectionTimingNever (): Promise<boolean> {
+        const connectionTiming = (await ConfigurationManager.getConfiguration()).matlabConnectionTiming
+        return connectionTiming === ConnectionTiming.Never
     }
 }
 

--- a/src/logging/TelemetryUtils.ts
+++ b/src/logging/TelemetryUtils.ts
@@ -13,7 +13,8 @@ export enum Actions {
     ShutdownMatlab = 'shutdownMATLAB',
     FormatDocument = 'formatDocument',
     GoToReference = 'goToReference',
-    GoToDefinition = 'goToDefinition'
+    GoToDefinition = 'goToDefinition',
+    DocumentSymbol = 'documentSymbol'
 }
 
 export enum ActionErrorConditions {
@@ -48,7 +49,7 @@ export function reportTelemetryAction(actionType: string, data = ''): void {
 
 /**
  * Reports telemetry about a settings change
- * 
+ *
  * @param settingName The setting's name
  * @param newValue The new value
  * @param oldValue The old value

--- a/src/providers/navigation/NavigationSupportProvider.ts
+++ b/src/providers/navigation/NavigationSupportProvider.ts
@@ -150,9 +150,8 @@ class NavigationSupportProvider {
             reportTelemetry(requestType, 'No document')
             return []
         }
-        await Indexer.indexDocument(textDocument)
         let codeData = FileInfoIndex.codeDataCache.get(uri)
-        if (codeData === null) {
+        if (codeData == null) {
             // Ask to index file
             await Indexer.indexDocument(textDocument)
             codeData = FileInfoIndex.codeDataCache.get(uri)

--- a/src/providers/navigation/NavigationSupportProvider.ts
+++ b/src/providers/navigation/NavigationSupportProvider.ts
@@ -64,7 +64,19 @@ export enum RequestType {
 }
 
 function reportTelemetry (type: RequestType, errorCondition = ''): void {
-    reportTelemetryAction(type === RequestType.Definition ? Actions.GoToDefinition : Actions.GoToReference, errorCondition)
+    let action: Actions
+    switch (type) {
+        case RequestType.Definition:
+            action = Actions.GoToDefinition
+            break
+        case RequestType.References:
+            action = Actions.GoToReference
+            break
+        case RequestType.DocumentSymbol:
+            action = Actions.DocumentSymbol
+            break
+    }
+    reportTelemetryAction(action, errorCondition)
 }
 
 /**

--- a/src/providers/navigation/NavigationSupportProvider.ts
+++ b/src/providers/navigation/NavigationSupportProvider.ts
@@ -63,7 +63,7 @@ export enum RequestType {
     DocumentSymbol
 }
 
-function reportTelemetry (type: RequestType, errorCondition = '') {
+function reportTelemetry (type: RequestType, errorCondition = ''): void {
     reportTelemetryAction(type === RequestType.Definition ? Actions.GoToDefinition : Actions.GoToReference, errorCondition)
 }
 
@@ -121,11 +121,11 @@ class NavigationSupportProvider {
      * @param requestType The type of request
      * @returns Array of symbols found in the document
      */
-    async handleDocumentSymbol(params: DocumentSymbolParams, documentManager: TextDocuments<TextDocument>, requestType: RequestType): Promise<SymbolInformation[]> {
+    async handleDocumentSymbol (params: DocumentSymbolParams, documentManager: TextDocuments<TextDocument>, requestType: RequestType): Promise<SymbolInformation[]> {
         // We only get the connection since the documentSymbol (aka outline) request
         // is called on nearly every edit. Calling getOrCreateMatlabConnection would
         // effectively make the onDemand launch setting act as onStart.
-        const matlabConnection = await MatlabLifecycleManager.getMatlabConnection();
+        const matlabConnection = await MatlabLifecycleManager.getMatlabConnection()
         if (matlabConnection == null) {
             reportTelemetry(requestType, ActionErrorConditions.MatlabUnavailable)
             return []
@@ -138,36 +138,36 @@ class NavigationSupportProvider {
             reportTelemetry(requestType, 'No document')
             return []
         }
-        let codeData = FileInfoIndex.codeDataCache.get(uri);
+        const codeData = FileInfoIndex.codeDataCache.get(uri)
         if (codeData == null) {
             reportTelemetry(requestType, 'No code data')
             return []
         }
         // Result symbols in documented
-        let result: SymbolInformation[] = [];
+        const result: SymbolInformation[] = []
         // Avoid duplicates coming from different data sources
-        let visitedRanges: Set<Range> = new Set();
+        const visitedRanges: Set<Range> = new Set()
         /**
          * Push symbol info to result set
          */
-        function pushSymbol(name: string, kind: SymbolKind, symbolRange: Range) {
+        function pushSymbol (name: string, kind: SymbolKind, symbolRange: Range): void {
             if (!visitedRanges.has(symbolRange)) {
-                result.push(SymbolInformation.create(name, kind, symbolRange, uri));
-                visitedRanges.add(symbolRange);
+                result.push(SymbolInformation.create(name, kind, symbolRange, uri))
+                visitedRanges.add(symbolRange)
             }
         }
         if (codeData.isClassDef && codeData.classInfo != null) {
-            let classInfo = codeData.classInfo;
+            const classInfo = codeData.classInfo
             // TODO: When can this be null if we're in a classInfo case?
             if (codeData.classInfo.range != null) {
-                pushSymbol(classInfo.name, SymbolKind.Class, codeData.classInfo.range);
+                pushSymbol(classInfo.name, SymbolKind.Class, codeData.classInfo.range)
             }
-            classInfo.methods.forEach((info, name) => pushSymbol(name, SymbolKind.Method, info.range));
-            classInfo.enumerations.forEach((info, name) => pushSymbol(name, SymbolKind.EnumMember, info.range));
-            classInfo.properties.forEach((info, name) => pushSymbol(name, SymbolKind.Property, info.range));
+            classInfo.methods.forEach((info, name) => pushSymbol(name, SymbolKind.Method, info.range))
+            classInfo.enumerations.forEach((info, name) => pushSymbol(name, SymbolKind.EnumMember, info.range))
+            classInfo.properties.forEach((info, name) => pushSymbol(name, SymbolKind.Property, info.range))
         }
-        codeData.functions.forEach((info, name) => pushSymbol(name, SymbolKind.Function, info.range));
-        return result;
+        codeData.functions.forEach((info, name) => pushSymbol(name, SymbolKind.Function, info.range))
+        return result
     }
 
     /**
@@ -288,7 +288,7 @@ class NavigationSupportProvider {
      * @param codeData The code data which is being searched
      * @returns The definition location(s), or null if no definition was found
      */
-    private findDefinitionInCodeData(uri: string, position: Position, expression: Expression, codeData: MatlabCodeData): Location[] | null {
+    private findDefinitionInCodeData (uri: string, position: Position, expression: Expression, codeData: MatlabCodeData): Location[] | null {
         // If first part of expression targeted - look for a local variable
         if (expression.selectedComponent === 0) {
             const containingFunction = codeData.findContainingFunction(position)

--- a/src/providers/navigation/NavigationSupportProvider.ts
+++ b/src/providers/navigation/NavigationSupportProvider.ts
@@ -13,7 +13,6 @@ import PathResolver from './PathResolver'
 import { connection } from '../../server'
 import LifecycleNotificationHelper from '../../lifecycle/LifecycleNotificationHelper'
 import { ActionErrorConditions, Actions, reportTelemetryAction } from '../../logging/TelemetryUtils'
-import { MatlabClassInfo } from '../../indexing/FileInfoIndex'
 
 /**
  * Represents a code expression, either a single identifier or a dotted expression.

--- a/src/server.ts
+++ b/src/server.ts
@@ -166,14 +166,16 @@ connection.onReferences(async params => {
 })
 
 connection.onDocumentSymbol(async params => {
-    return await NavigationSupportProvider.handleDocumentSymbol(params, documentManager, RequestType.DocumentSymbol)
+    // We return an unawaited promise here to rate limit the number of open requests from the client
+    // eslint-disable-next-line @typescript-eslint/return-await
+    return NavigationSupportProvider.handleDocumentSymbol(params, documentManager, RequestType.DocumentSymbol)
 })
 
 // Start listening to open/change/close text document events
 documentManager.listen(connection)
 
 /** -------------------- Helper Functions -------------------- **/
-function reportFileOpened(document: TextDocument) {
+function reportFileOpened (document: TextDocument): void {
     const roughSize = Math.ceil(document.getText().length / 1024) // in KB
     reportTelemetryAction(Actions.OpenFile, roughSize.toString())
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -70,7 +70,8 @@ connection.onInitialize((params: InitializeParams) => {
             referencesProvider: true,
             signatureHelpProvider: {
                 triggerCharacters: ['(', ',']
-            }
+            },
+            documentSymbolProvider: true
         }
     }
 
@@ -162,6 +163,10 @@ connection.onDefinition(async params => {
 
 connection.onReferences(async params => {
     return await NavigationSupportProvider.handleDefOrRefRequest(params, documentManager, RequestType.References)
+})
+
+connection.onDocumentSymbol(async params => {
+    return await NavigationSupportProvider.handleDocumentSymbol(params, documentManager, RequestType.DocumentSymbol)
 })
 
 // Start listening to open/change/close text document events

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "target": "ES6",
         "rootDir": "./src",
         "outDir": "./out",
-		"sourceMap": true,
+        "sourceMap": true,
         "lib": [
             "ES6"
         ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "target": "ES6",
         "rootDir": "./src",
         "outDir": "./out",
+		"sourceMap": true,
         "lib": [
             "ES6"
         ],


### PR DESCRIPTION
Here's an initial attempt at outline support for https://github.com/mathworks/MATLAB-extension-for-vscode/issues/1

This has a few responsiveness bugs I need to investigate, so please don't actually merge yet. Still I wanted to get some initial feedback.

Some bits of feedback I'd like to hear about:

* Is this the right location? It feels navigation-related so I put it there. I could also imagine making a separate provider folder like `symbols` or `structure`.
* I've tried to integrate well with the MATLAB startup option. Editors make requests for document symbols very frequently so I chose to make the document symbol request not trigger a MATLAB start with `onDemand` as mentioned in my comment.
* One UX issue I didn't immediately see how to solve is: suppose you have A.m and foo.m open at VSCode launch. The documentSymbol request fires and since MATLAB hasn't started, we don't have any code index info yet. Right now I just return empty. It would be nice if I could wait on a promise or something for files to be indexed and then immediately return a response once the system is up and running. Any ideas on whether or not there's anything in the existing server that I could leverage for this?

Here's a screenshot of this in action:

<img width="419" alt="image" src="https://user-images.githubusercontent.com/43882944/236561793-be8fdfe6-c275-4b46-85fb-d4e9bc34fb4f.png">

Things left to do

- [x] Fix handling of classdef folders
- [x] Look into apparent stale data showing up with classdefs
- [x] Look at responsiveness for already opened files. Wait on MATLAB connection. Ensure promises don't stack up.
