### PR TITLE
Address responsiveness issues with documentSymbol

### DIFF
--- a/src/indexing/DocumentIndexer.ts
+++ b/src/indexing/DocumentIndexer.ts
@@ -2,6 +2,8 @@
 
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import Indexer from './Indexer'
+import { text } from 'stream/consumers'
+import FileInfoIndex from './FileInfoIndex'
 
 const INDEXING_DELAY = 500 // Delay (in ms) after keystroke before attempting to re-index the document
 
@@ -48,6 +50,24 @@ class DocumentIndexer {
         if (timerId != null) {
             clearTimeout(timerId)
             this.pendingFilesToIndex.delete(uri)
+        }
+    }
+
+    /**
+     * Ensure that @param textDocument is fully indexed and up to date by flushing any pending indexing tasks
+     * and then forcing an index. This is intended to service requests like documentSymbols where returning
+     * stale info could be confusing.
+     *
+     * @param textDocument The document to index
+     */
+    async ensureDocumentIndexIsUpdated (textDocument: TextDocument): Promise<void> {
+        const uri = textDocument.uri
+        if (this.pendingFilesToIndex.has(uri)) {
+            this.clearTimerForDocumentUri(uri)
+            await Indexer.indexDocument(textDocument)
+        }
+        if (!FileInfoIndex.codeDataCache.has(uri)) {
+            await Indexer.indexDocument(textDocument)
         }
     }
 }

--- a/src/providers/navigation/NavigationSupportProvider.ts
+++ b/src/providers/navigation/NavigationSupportProvider.ts
@@ -13,6 +13,7 @@ import PathResolver from './PathResolver'
 import { connection } from '../../server'
 import LifecycleNotificationHelper from '../../lifecycle/LifecycleNotificationHelper'
 import { ActionErrorConditions, Actions, reportTelemetryAction } from '../../logging/TelemetryUtils'
+import DocumentIndexer from '../../indexing/DocumentIndexer'
 
 /**
  * Represents a code expression, either a single identifier or a dotted expression.
@@ -127,13 +128,21 @@ class NavigationSupportProvider {
     }
 
     /**
+     * Caches document symbols for URIs to deal with the case when indexing
+     * temporarily fails while the user is in the middle of an edit. We might
+     * consider moving logic like this into the indexer logic later as clearing
+     * out index data in the middle of an edit will have other ill effects.
+     */
+    private readonly _documentSymbolCache = new Map<string, SymbolInformation[]>()
+
+    /**
      *
      * @param params Parameters for the document symbol request
      * @param documentManager The text document manager
      * @param requestType The type of request
      * @returns Array of symbols found in the document
      */
-    async handleDocumentSymbol (params: DocumentSymbolParams, documentManager: TextDocuments<TextDocument>, requestType: RequestType): Promise<SymbolInformation[]> {
+    async handleDocumentSymbol (params: DocumentSymbolParams, documentManager: TextDocuments<TextDocument>, requestType: RequestType): Promise<SymbolInformation[] | null> {
         // Get or wait for MATLAB connection to handle files opened before MATLAB is ready.
         // Calling getOrCreateMatlabConnection would effectively make the onDemand launch
         // setting act as onStart.
@@ -150,12 +159,9 @@ class NavigationSupportProvider {
             reportTelemetry(requestType, 'No document')
             return []
         }
-        let codeData = FileInfoIndex.codeDataCache.get(uri)
-        if (codeData == null) {
-            // Ask to index file
-            await Indexer.indexDocument(textDocument)
-            codeData = FileInfoIndex.codeDataCache.get(uri)
-        }
+        // Ensure document index is up to date
+        await DocumentIndexer.ensureDocumentIndexIsUpdated(textDocument)
+        const codeData = FileInfoIndex.codeDataCache.get(uri)
         if (codeData == null) {
             reportTelemetry(requestType, 'No code data')
             return []
@@ -183,6 +189,18 @@ class NavigationSupportProvider {
             classInfo.properties.forEach((info, name) => pushSymbol(name, SymbolKind.Property, info.range))
         }
         codeData.functions.forEach((info, name) => pushSymbol(name, info.isClassMethod ? SymbolKind.Method : SymbolKind.Function, info.range))
+        /**
+         * Handle a case when the indexer fails due to the user being in the middle of an edit.
+         * Here the documentSymbol cache has some symbols but the codeData cache has none. So we
+         * assume that the user will soon fix their code and just fall back to what we knew for now.
+         */
+        if (result.length === 0) {
+            const cached = this._documentSymbolCache.get(uri) ?? result
+            if (cached.length > 0) {
+                return cached
+            }
+        }
+        this._documentSymbolCache.set(uri, result)
         return result
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -166,9 +166,7 @@ connection.onReferences(async params => {
 })
 
 connection.onDocumentSymbol(async params => {
-    // We return an unawaited promise here to rate limit the number of open requests from the client
-    // eslint-disable-next-line @typescript-eslint/return-await
-    return NavigationSupportProvider.handleDocumentSymbol(params, documentManager, RequestType.DocumentSymbol)
+    return await NavigationSupportProvider.handleDocumentSymbol(params, documentManager, RequestType.DocumentSymbol)
 })
 
 // Start listening to open/change/close text document events


### PR DESCRIPTION
Handle new files properly and be more friendly when the document temporarily has invalid syntax because the user is in the middle of an edit. I also removed the unnecessary complexity of using an unawaited promise from the original documentSymbol request. Further experimentation showed this didn't matter.