### PR TITLE
Clear linting diagnostics & fix launching w/ onDemand setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matlab-language-server",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Language Server for MATLAB code",
   "main": "./src/index.ts",
   "scripts": {

--- a/src/lifecycle/MatlabLifecycleManager.ts
+++ b/src/lifecycle/MatlabLifecycleManager.ts
@@ -144,7 +144,7 @@ class MatlabLifecycleManager {
         }
 
         // No active connection - should create a connection if desired
-        if (await this._isMatlabConnectionTimingNever()) {
+        if (!(await this._isMatlabConnectionTimingNever())) {
             const matlabProcess = await this.connectToMatlab(connection)
             return matlabProcess.getConnection()
         }

--- a/src/providers/linting/LintingSupportProvider.ts
+++ b/src/providers/linting/LintingSupportProvider.ts
@@ -122,6 +122,13 @@ class LintingSupportProvider {
         })
     }
 
+    clearDiagnosticsForDocument (textDocument: TextDocument): void {
+        void connection.sendDiagnostics({
+            uri: textDocument.uri,
+            diagnostics: []
+        })
+    }
+
     /**
      * Handles a request for code actions.
      *

--- a/src/server.ts
+++ b/src/server.ts
@@ -114,6 +114,10 @@ documentManager.onDidOpen(params => {
     void DocumentIndexer.indexDocument(params.document)
 })
 
+documentManager.onDidClose(params => {
+    LintingSupportProvider.clearDiagnosticsForDocument(params.document)
+})
+
 // Handles files saved
 documentManager.onDidSave(params => {
     void LintingSupportProvider.lintDocument(params.document, connection)


### PR DESCRIPTION
This change resolves two bugs:
1. When files are closed, any linting diagnostics should be cleared
2. Fixed launching MATLAB when the `MATLAB Connection Timing` setting is set to `onDemand`