### PR TITLE
Dlilley.bugfix improve navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ MATLAB language server supports these editors by installing the corresponding ex
 
 Fixed:
 * Diagnostic suppression should be placed at correct location when '%' is contained within string
+* Improved navigation to files within MATLAB packages within the VS Code workspace but not on the MATLAB path
+* Prevented navigation to private/local functions from other files
 
 ### 1.1.2
 Release date: 2023-05-31

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ MATLAB language server supports these editors by installing the corresponding ex
 
 Fixed:
 * Diagnostic suppression should be placed at correct location when '%' is contained within string
-* Improved navigation to files within MATLAB packages within the VS Code workspace but not on the MATLAB path
+* Improved navigation to files inside MATLAB packages within the VS Code workspace but not on the MATLAB path
 * Prevented navigation to private/local functions from other files
 
 ### 1.1.2

--- a/matlab/+matlabls/+handlers/NavigationSupportHandler.m
+++ b/matlab/+matlabls/+handlers/NavigationSupportHandler.m
@@ -29,6 +29,23 @@ classdef (Hidden) NavigationSupportHandler < matlabls.handlers.FeatureHandler
                 response.data{n} = struct(name = name, path = path);
             end
 
+            % For any names which are not found, try CDing to the context
+            % file's directory and searching again
+            sArray = [response.data{:}];
+            missingPaths = cellfun(@isempty, {sArray.path});
+            missingIndices = find(missingPaths);
+
+            if ~isempty(missingIndices)
+                returnDir = cd(fileparts(contextFile));
+                for n = missingIndices
+                    path = matlabls.internal.resolvePath(names{n}, contextFile);
+                    if ~isempty(path)
+                        response.data{n}.path = path;
+                    end
+                end
+                cd(returnDir);
+            end
+
             this.CommManager.publish(this.ResolvePathResponseChannel, response);
         end
     end

--- a/src/providers/navigation/NavigationSupportProvider.ts
+++ b/src/providers/navigation/NavigationSupportProvider.ts
@@ -505,9 +505,7 @@ class NavigationSupportProvider {
      * @returns true if the function should be visible from the given URI; false otherwise
      */
     private isFunctionVisibleFromUri (uri: string, funcData: MatlabFunctionInfo): boolean {
-        const functionUri = funcData.uri
-
-        return uri === functionUri || funcData.visibility === FunctionVisibility.Public
+        return uri === funcData.uri || funcData.visibility === FunctionVisibility.Public
     }
 
     /**

--- a/src/providers/navigation/NavigationSupportProvider.ts
+++ b/src/providers/navigation/NavigationSupportProvider.ts
@@ -464,7 +464,9 @@ class NavigationSupportProvider {
             // Check functions
             for (const [funcName, funcData] of fileCodeData.functions) {
                 const funcMatch = (match === '') ? funcName : match + '.' + funcName
-                if (expressionToMatch === funcMatch) {
+
+                // Need to ensure that a function with a matching name should also be visible from the current file.
+                if (expressionToMatch === funcMatch && this.isFunctionVisibleFromUri(uri, funcData)) {
                     const range = funcData.declaration ?? Range.create(0, 0, 0, 0)
                     return [Location.create(funcData.uri, range)]
                 }
@@ -492,6 +494,20 @@ class NavigationSupportProvider {
         }
 
         return null
+    }
+
+    /**
+     * Determines whether the given function should be visible from the given file URI.
+     * The function is visible if it is contained within the same file, or is public.
+     *
+     * @param uri The file's URI
+     * @param funcData The function data
+     * @returns true if the function should be visible from the given URI; false otherwise
+     */
+    private isFunctionVisibleFromUri (uri: string, funcData: MatlabFunctionInfo): boolean {
+        const functionUri = funcData.uri
+
+        return uri === functionUri || funcData.visibility === FunctionVisibility.Public
     }
 
     /**


### PR DESCRIPTION
These changes address two issues:
1. mathworks/MATLAB-extension-for-vscode#5 - Improves navigation to files within packages when those packages are not on the MATLAB path
2. mathworks/MATLAB-extension-for-vscode#31 - Prevents navigation to private/local functions from other files

For (1), we first try to resolve an identifier via the MATLAB path (as before). But now, if that resolution fails, we temporarily `cd` into the source file's directory, thereby forcing it onto the path. We then attempt a name resolution again before `cd`ing back to the original directory. If the name resolution still fails, we fall back to the code data cache.

For (2), a check was added to ensure that 'private' functions in other files cannot be matched when searching for a definition.