### PR TITLE
Improve navigation between files within packages.

### DIFF
--- a/matlab/+matlabls/+handlers/NavigationSupportHandler.m
+++ b/matlab/+matlabls/+handlers/NavigationSupportHandler.m
@@ -36,7 +36,7 @@ classdef (Hidden) NavigationSupportHandler < matlabls.handlers.FeatureHandler
             missingIndices = find(missingPaths);
 
             if ~isempty(missingIndices)
-                returnDir = cd(fileparts(contextFile));
+                returnDir = cdToPackageRoot(contextFile);
                 for n = missingIndices
                     path = matlabls.internal.resolvePath(names{n}, contextFile);
                     if ~isempty(path)
@@ -49,4 +49,23 @@ classdef (Hidden) NavigationSupportHandler < matlabls.handlers.FeatureHandler
             this.CommManager.publish(this.ResolvePathResponseChannel, response);
         end
     end
+end
+
+function returnDir = cdToPackageRoot (filePath)
+    % Given a file path, CDs to the directory at the root-level of the
+    % file's package structure. If the file is not within a package,
+    % this CDs to the file's directory.
+
+    splitDirs = strsplit(fileparts(filePath), filesep);
+
+    % Determine how far up the path we need to CD
+    lastInd = numel(splitDirs);
+    while lastInd > 1
+        if ~startsWith(splitDirs(lastInd), '+')
+            break;
+        end
+        lastInd = lastInd - 1;
+    end
+
+    returnDir = cd(strjoin(splitDirs(1:lastInd), filesep));
 end


### PR DESCRIPTION
This change enables navigation between files within a package structure.

Consider the following file structure:
- +package1
    - +package2
        - func2.m
    - func1.m
- myScript.m

From within `myScript.m`, navigation works as expected to either `package1.func1` or `package1.package2.func2`.
However, navigation does not work from `func1.m` to `package1.package2.func2`.

This change modifies where we temporarily CD to when trying to resolve identifiers. Instead of CDing to the source file's directory, we CD to the top level directory outside the package structure.

For example, if the source file is at `C:\path\to\+my\+package\foo.m`, then we CD to `C:\path\to`.