### PR TITLE
Fix issue preventing signin when launching MATLAB on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Fixed:
 * Diagnostic suppression should be placed at correct location when '%' is contained within string
 * Improved navigation to files inside MATLAB packages within the VS Code workspace but not on the MATLAB path
 * Prevented navigation to private/local functions from other files
+* MATLAB sign-in is no longer blocked on Windows
 
 ### 1.1.2
 Release date: 2023-05-31

--- a/src/lifecycle/MatlabLifecycleManager.ts
+++ b/src/lifecycle/MatlabLifecycleManager.ts
@@ -398,14 +398,12 @@ class MatlabProcess {
         this._matlabProcess = matlabProcess
         this._matlabConnection = matlabConnection
 
-        // Handle errors from MATLAB's standard err
+        // Handle messages from MATLAB's standard err channel. Because MATLAB is launched
+        // with the -log flag, all of MATLAB's output is pushed through stderr. Write this
+        // to a log file.
         this._matlabProcess.stderr?.on('data', data => {
             const stderrStr: string = data.toString().trim()
-            if (stderrStr.startsWith('MEMORY MANAGEMENT')) { return }
-
-            const msg = `MATLAB command stderr: ${stderrStr}`
-            Logger.log(msg)
-            this._connection.window.showErrorMessage(msg)
+            Logger.writeMatlabLog(stderrStr)
         })
 
         /**
@@ -464,7 +462,6 @@ class MatlabProcess {
 
         const args = [
             '-log',
-            '-logfile', path.join(Logger.logDir, 'matlabls.log'), // Log file
             '-memmgr', 'release', // Memory manager
             '-noAppIcon', // Hide MATLAB application icon in taskbar/dock, if applicable
             '-nosplash', // Hide splash screen

--- a/src/logging/Logger.ts
+++ b/src/logging/Logger.ts
@@ -5,9 +5,13 @@ import * as os from 'os'
 import * as path from 'path'
 import { RemoteConsole } from 'vscode-languageserver'
 
+const SERVER_LOG = 'languageServerLog.txt'
+const MATLAB_LOG = 'matlabLog.txt'
+
 class Logger {
     private readonly _logDir: string
-    private readonly _logFile: string
+    private readonly languageServerLogFile: string
+    private readonly matlabLogFile: string
     private _console: RemoteConsole | null = null
 
     constructor () {
@@ -22,7 +26,8 @@ class Logger {
         fs.mkdirSync(this._logDir)
 
         // Get name of log file
-        this._logFile = path.join(this._logDir, 'matlabLanguageServerLog.txt')
+        this.languageServerLogFile = path.join(this._logDir, SERVER_LOG)
+        this.matlabLogFile = path.join(this._logDir, MATLAB_LOG)
     }
 
     /**
@@ -43,7 +48,7 @@ class Logger {
     log (message: string): void {
         const msg = `(${getCurrentTimeString()}) matlabls: ${message}`
         this._console?.log(msg)
-        this._writeToLogFile(msg)
+        this._writeToLogFile(msg, this.languageServerLogFile)
     }
 
     /**
@@ -54,7 +59,7 @@ class Logger {
     warn (message: string): void {
         const msg = `(${getCurrentTimeString()}) matlabls - WARNING: ${message}`
         this._console?.warn(msg)
-        this._writeToLogFile(msg)
+        this._writeToLogFile(msg, this.languageServerLogFile)
     }
 
     /**
@@ -65,17 +70,27 @@ class Logger {
     error (message: string): void {
         const msg = `(${getCurrentTimeString()}) matlabls - ERROR: ${message}`
         this._console?.error(msg)
-        this._writeToLogFile(msg)
+        this._writeToLogFile(msg, this.languageServerLogFile)
+    }
+
+    /**
+     * Log MATLAB application output to a log file on disk, separate from
+     * the language server logs.
+     *
+     * @param message The message
+     */
+    writeMatlabLog (message: string): void {
+        this._writeToLogFile(message, this.matlabLogFile)
     }
 
     public get logDir (): string {
         return this._logDir
     }
 
-    private _writeToLogFile (message: string): void {
+    private _writeToLogFile (message: string, filePath: string): void {
         // Log to file
         fs.writeFile(
-            this._logFile,
+            filePath,
             `${message}\n`,
             { flag: 'a+' },
             err => {


### PR DESCRIPTION
This change fixes an issue which prevents MATLAB sign-in when launching MATLAB on Windows. 

When MATLAB is not signed-in, launching the application should prompt the user to sign-in. However, when MATLAB is launched with both the `-log` and `-logfile` startup flags, this process does not work correctly and an error is displayed. This issue is being tracked internally and will be fixed within MATLAB, but can be worked around by eliminating the usage of `-logfile`.

When `-logfile` is eliminated, the output which was previously being logged by MATLAB is now communicated over stderr, and we need to write to disk manually. 