### PR TITLE
MATLAB language server - v1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ MATLAB language server supports these editors by installing the corresponding ex
 
 ### Unreleased
 
+### 1.2.2
+Release date: 2024-05-17
+
 Fixed:
 * Resolved packaging failure on Mac
 * Resolved connecting to MATLAB in proxy environment

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matlab-language-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "matlab-language-server",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matlab-language-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Language Server for MATLAB code",
   "main": "./src/index.ts",
   "bin": "./out/index.js",


### PR DESCRIPTION
Preparing changes for v1.2.2 update of the MATLAB language server.

See README.md for the changes included.